### PR TITLE
feat(api): add /shard endpoint for row-to-shard mapping

### DIFF
--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -1985,6 +1985,14 @@
           },
           "400": {
             "description": "Row index out of bounds.",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/Cache-Control"
+              },
+              "Access-Control-Allow-Origin": {
+                "$ref": "#/components/headers/Access-Control-Allow-Origin"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2001,6 +2009,27 @@
           },
           "422": {
             "$ref": "#/components/responses/DatasetConfigSplit422"
+          },
+          "500": {
+            "description": "The server crashed, the response still hasn't been generated (the process is asynchronous), or the response couldn't be generated successfully due to corrupted metadata. The client can retry after a time, in particular in the case of the response still being processed.",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/Cache-Control"
+              },
+              "Access-Control-Allow-Origin": {
+                "$ref": "#/components/headers/Access-Control-Allow-Origin"
+              },
+              "X-Error-Code": {
+                "$ref": "#/components/headers/X-Error-Code-500-common"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomError"
+                }
+              }
+            }
           }
         }
       }

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -957,6 +957,41 @@
           }
         }
       },
+      "ShardInfoResponse": {
+        "type": "object",
+        "required": [
+          "row_index",
+          "parquet_shard_index",
+          "parquet_shard_file"
+        ],
+        "properties": {
+          "row_index": {
+            "type": "integer"
+          },
+          "original_shard_index": {
+            "type": "integer",
+            "nullable": true
+          },
+          "original_shard_start_row": {
+            "type": "integer",
+            "nullable": true
+          },
+          "original_shard_end_row": {
+            "type": "integer",
+            "nullable": true
+          },
+          "original_shard_info": {
+            "type": "string",
+            "nullable": true
+          },
+          "parquet_shard_index": {
+            "type": "integer"
+          },
+          "parquet_shard_file": {
+            "type": "string"
+          }
+        }
+      },
       "InfoResponse": {
         "type": "object",
         "required": ["dataset_info", "partial"],
@@ -1893,6 +1928,83 @@
     }
   },
   "paths": {
+    "/shard": {
+      "get": {
+        "summary": "Get shard info for a row",
+        "description": "Get the original and parquet shard information for a specific row in a dataset split.",
+        "operationId": "getShard",
+        "security": [
+          {},
+          {
+            "AuthorizationHuggingFaceApiToken": []
+          },
+          {
+            "AuthorizationHuggingFaceJWT": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RequiredDataset"
+          },
+          {
+            "$ref": "#/components/parameters/RequiredConfig"
+          },
+          {
+            "$ref": "#/components/parameters/RequiredSplit"
+          },
+          {
+            "name": "row",
+            "in": "query",
+            "description": "The row index (0-based).",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 0
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The shard information.",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/Cache-Control"
+              },
+              "Access-Control-Allow-Origin": {
+                "$ref": "#/components/headers/Access-Control-Allow-Origin"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShardInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Row index out of bounds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomError"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Common401"
+          },
+          "404": {
+            "$ref": "#/components/responses/DatasetConfigSplit404"
+          },
+          "422": {
+            "$ref": "#/components/responses/DatasetConfigSplit422"
+          }
+        }
+      }
+    },
     "/splits": {
       "get": {
         "summary": "List of splits",

--- a/e2e/tests/test_56_shard.py
+++ b/e2e/tests/test_56_shard.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The HuggingFace Authors.
+
+from .utils import get_default_config_split, poll_until_ready_and_assert
+
+
+def test_shard_endpoint(normal_user_public_dataset: str) -> None:
+    """Test /shard endpoint returns correct shard info."""
+    dataset = normal_user_public_dataset
+    config, split = get_default_config_split()
+
+    # First ensure dataset is processed (wait for config-parquet-and-info)
+    poll_until_ready_and_assert(
+        relative_url=f"/info?dataset={dataset}&config={config}",
+        dataset=dataset,
+        should_retry_x_error_codes=["ResponseNotFound"],
+    )
+
+    # Now test shard endpoint
+    shard_response = poll_until_ready_and_assert(
+        relative_url=f"/shard?dataset={dataset}&config={config}&split={split}&row=0",
+        dataset=dataset,
+        should_retry_x_error_codes=["ResponseNotFound"],
+    )
+
+    content = shard_response.json()
+    assert "row_index" in content
+    assert content["row_index"] == 0
+    assert "parquet_shard_index" in content
+    assert "parquet_shard_file" in content
+    # original_shard_index may be None for legacy/single-shard datasets
+
+
+def test_shard_endpoint_row_out_of_bounds(normal_user_public_dataset: str) -> None:
+    """Test /shard endpoint returns 400 for invalid row."""
+    dataset = normal_user_public_dataset
+    config, split = get_default_config_split()
+
+    # First ensure dataset is processed
+    poll_until_ready_and_assert(
+        relative_url=f"/info?dataset={dataset}&config={config}",
+        dataset=dataset,
+        should_retry_x_error_codes=["ResponseNotFound"],
+    )
+
+    # Test with row out of bounds
+    poll_until_ready_and_assert(
+        relative_url=f"/shard?dataset={dataset}&config={config}&split={split}&row=999999",
+        expected_status_code=400,
+        expected_error_code="RowOutOfBounds",
+        dataset=dataset,
+        should_retry_x_error_codes=["ResponseNotFound"],
+    )

--- a/libs/libapi/src/libapi/shard_utils.py
+++ b/libs/libapi/src/libapi/shard_utils.py
@@ -25,9 +25,7 @@ class ShardInfoResponse(TypedDict):
     parquet_shard_file: str
 
 
-def get_original_shard_for_row(
-    row_index: int, original_shard_lengths: list[int]
-) -> OriginalShardInfo:
+def get_original_shard_for_row(row_index: int, original_shard_lengths: list[int]) -> OriginalShardInfo:
     """Cumulative sum to find which original shard contains row."""
     cumulative = 0
     for shard_idx, length in enumerate(original_shard_lengths):
@@ -97,9 +95,7 @@ def get_shard_info(
 
     # Always compute parquet shard (from shard_lengths)
     shard_lengths = split_info.get("shard_lengths")
-    parquet_info = get_parquet_shard_for_row(
-        row_index, shard_lengths, parquet_files, split
-    )
+    parquet_info = get_parquet_shard_for_row(row_index, shard_lengths, parquet_files, split)
 
     # Check for original_shard_lengths - KEY EXISTENCE, not nullity!
     if "original_shard_lengths" not in split_info:

--- a/libs/libapi/src/libapi/shard_utils.py
+++ b/libs/libapi/src/libapi/shard_utils.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The HuggingFace Authors.
+
+from typing import Any, Optional, TypedDict
+
+
+class OriginalShardInfo(TypedDict):
+    original_shard_index: int
+    original_shard_start_row: int
+    original_shard_end_row: int
+
+
+class ParquetShardInfo(TypedDict):
+    parquet_shard_index: int
+    parquet_shard_file: str
+
+
+class ShardInfoResponse(TypedDict):
+    row_index: int
+    original_shard_index: Optional[int]
+    original_shard_start_row: Optional[int]
+    original_shard_end_row: Optional[int]
+    original_shard_info: Optional[str]  # Explanation when missing
+    parquet_shard_index: int
+    parquet_shard_file: str
+
+
+def get_original_shard_for_row(
+    row_index: int, original_shard_lengths: list[int]
+) -> OriginalShardInfo:
+    """Cumulative sum to find which original shard contains row."""
+    cumulative = 0
+    for shard_idx, length in enumerate(original_shard_lengths):
+        if cumulative + length > row_index:
+            return {
+                "original_shard_index": shard_idx,
+                "original_shard_start_row": cumulative,
+                "original_shard_end_row": cumulative + length - 1,
+            }
+        cumulative += length
+    raise IndexError(f"row_index {row_index} out of bounds")
+
+
+def get_parquet_shard_for_row(
+    row_index: int,
+    shard_lengths: Optional[list[int]],
+    parquet_files: list[dict[str, Any]],
+    split: str,
+) -> ParquetShardInfo:
+    """Find which parquet file contains the row."""
+    # Filter and sort parquet files for this split
+    split_files = sorted(
+        [f for f in parquet_files if f.get("split") == split],
+        key=lambda f: f["filename"],
+    )
+
+    if not split_files:
+        return {"parquet_shard_index": 0, "parquet_shard_file": f"{split}.parquet"}
+
+    if not shard_lengths or len(shard_lengths) <= 1:
+        # Single shard
+        return {
+            "parquet_shard_index": 0,
+            "parquet_shard_file": split_files[0]["filename"],
+        }
+
+    cumulative = 0
+    for shard_idx, length in enumerate(shard_lengths):
+        if cumulative + length > row_index:
+            return {
+                "parquet_shard_index": shard_idx,
+                "parquet_shard_file": split_files[shard_idx]["filename"]
+                if shard_idx < len(split_files)
+                else f"{split}-{shard_idx:05d}.parquet",
+            }
+        cumulative += length
+    raise IndexError(f"row_index {row_index} out of bounds")
+
+
+def get_shard_info(
+    row_index: int,
+    split_info: dict[str, Any],
+    parquet_files: list[dict[str, Any]],
+    split: str,
+) -> ShardInfoResponse:
+    """
+    Main entry point: compute shard info for a row.
+
+    CRITICAL: Check for key EXISTENCE, not nullity!
+    The field is MISSING from JSON when None, not null.
+    """
+    num_examples = split_info.get("num_examples", 0)
+
+    # Validate bounds
+    if row_index < 0 or row_index >= num_examples:
+        raise IndexError(f"row_index {row_index} out of bounds (0-{num_examples - 1})")
+
+    # Always compute parquet shard (from shard_lengths)
+    shard_lengths = split_info.get("shard_lengths")
+    parquet_info = get_parquet_shard_for_row(
+        row_index, shard_lengths, parquet_files, split
+    )
+
+    # Check for original_shard_lengths - KEY EXISTENCE, not nullity!
+    if "original_shard_lengths" not in split_info:
+        return {
+            "row_index": row_index,
+            "original_shard_index": None,
+            "original_shard_start_row": None,
+            "original_shard_end_row": None,
+            "original_shard_info": "not available - dataset predates shard tracking or has single input shard",
+            **parquet_info,
+        }
+
+    original_shard_lengths = split_info["original_shard_lengths"]
+
+    # Sanity check: validate metadata integrity
+    if sum(original_shard_lengths) != num_examples:
+        raise ValueError(
+            f"Corrupted metadata: sum(original_shard_lengths)={sum(original_shard_lengths)} "
+            f"!= num_examples={num_examples}"
+        )
+
+    original_info = get_original_shard_for_row(row_index, original_shard_lengths)
+
+    return {
+        "row_index": row_index,
+        "original_shard_index": original_info["original_shard_index"],
+        "original_shard_start_row": original_info["original_shard_start_row"],
+        "original_shard_end_row": original_info["original_shard_end_row"],
+        "original_shard_info": None,
+        **parquet_info,
+    }

--- a/libs/libapi/tests/test_shard_utils.py
+++ b/libs/libapi/tests/test_shard_utils.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The HuggingFace Authors.
+
+import pytest
+from libapi.shard_utils import (
+    get_original_shard_for_row,
+    get_parquet_shard_for_row,
+    get_shard_info,
+)
+
+
+def test_get_original_shard_for_row_standard() -> None:
+    """Row 150 with lengths [100, 100, 100, 100] -> shard 1, rows 100-199"""
+    result = get_original_shard_for_row(150, [100, 100, 100, 100])
+    assert result["original_shard_index"] == 1
+    assert result["original_shard_start_row"] == 100
+    assert result["original_shard_end_row"] == 199
+
+
+def test_get_original_shard_for_row_first_shard() -> None:
+    """Row 0 -> shard 0"""
+    result = get_original_shard_for_row(0, [100, 100, 100, 100])
+    assert result["original_shard_index"] == 0
+    assert result["original_shard_start_row"] == 0
+    assert result["original_shard_end_row"] == 99
+
+
+def test_get_original_shard_for_row_last_row() -> None:
+    """Row 399 (last) -> shard 3"""
+    result = get_original_shard_for_row(399, [100, 100, 100, 100])
+    assert result["original_shard_index"] == 3
+
+
+def test_get_original_shard_for_row_boundary() -> None:
+    """Row 100 (exactly at boundary) -> shard 1, not shard 0"""
+    result = get_original_shard_for_row(100, [100, 100, 100, 100])
+    assert result["original_shard_index"] == 1
+    assert result["original_shard_start_row"] == 100
+
+
+def test_get_parquet_shard_for_row_single() -> None:
+    """Single shard dataset -> always index 0"""
+    parquet_files = [{"filename": "train.parquet", "split": "train"}]
+    result = get_parquet_shard_for_row(50, None, parquet_files, "train")
+    assert result["parquet_shard_index"] == 0
+
+
+def test_get_parquet_shard_for_row_multi() -> None:
+    """Multi-shard with lengths [200, 200] -> correct index"""
+    parquet_files = [
+        {"filename": "train-00000-of-00002.parquet", "split": "train"},
+        {"filename": "train-00001-of-00002.parquet", "split": "train"},
+    ]
+    result = get_parquet_shard_for_row(150, [200, 200], parquet_files, "train")
+    assert result["parquet_shard_index"] == 0
+    result = get_parquet_shard_for_row(250, [200, 200], parquet_files, "train")
+    assert result["parquet_shard_index"] == 1
+
+
+def test_missing_original_shard_lengths() -> None:
+    """Legacy dataset - key MISSING (not null) -> graceful handling"""
+    split_info = {"num_examples": 400, "shard_lengths": [200, 200]}
+    # Note: "original_shard_lengths" key is MISSING, not None
+    parquet_files = [
+        {"filename": "train-00000-of-00002.parquet", "split": "train"},
+        {"filename": "train-00001-of-00002.parquet", "split": "train"},
+    ]
+    result = get_shard_info(150, split_info, parquet_files, "train")
+    assert result["original_shard_index"] is None
+    assert result["original_shard_info"] is not None  # Contains explanation
+
+
+def test_corrupted_metadata_sum_mismatch() -> None:
+    """sum(original_shard_lengths) != num_examples -> ValueError"""
+    split_info = {
+        "num_examples": 400,
+        "shard_lengths": [200, 200],
+        "original_shard_lengths": [100, 100],  # Sum = 200 != 400
+    }
+    parquet_files = [{"filename": "train.parquet", "split": "train"}]
+    with pytest.raises(ValueError, match="Corrupted metadata"):
+        get_shard_info(150, split_info, parquet_files, "train")
+
+
+def test_row_out_of_bounds() -> None:
+    """row >= num_examples -> IndexError"""
+    split_info = {"num_examples": 400, "shard_lengths": [200, 200]}
+    parquet_files = [{"filename": "train.parquet", "split": "train"}]
+    with pytest.raises(IndexError):
+        get_shard_info(500, split_info, parquet_files, "train")

--- a/libs/libapi/tests/test_shard_utils.py
+++ b/libs/libapi/tests/test_shard_utils.py
@@ -2,6 +2,7 @@
 # Copyright 2025 The HuggingFace Authors.
 
 import pytest
+
 from libapi.shard_utils import (
     get_original_shard_for_row,
     get_parquet_shard_for_row,

--- a/services/api/src/api/app.py
+++ b/services/api/src/api/app.py
@@ -22,6 +22,7 @@ from starlette_prometheus import PrometheusMiddleware
 
 from api.config import AppConfig, EndpointConfig
 from api.routes.endpoint import EndpointsDefinition, create_endpoint
+from api.routes.shard import create_shard_endpoint
 
 
 def create_app() -> Starlette:
@@ -105,6 +106,22 @@ def create_app_with_config(app_config: AppConfig, endpoint_config: EndpointConfi
         )
         for endpoint_name, step_by_input_type in endpoints_definition.step_by_input_type_and_endpoint.items()
     ] + [
+        # Custom endpoint for shard lookup (compute-on-cache, not a standard EndpointConfig endpoint)
+        Route(
+            "/shard",
+            endpoint=create_shard_endpoint(
+                hf_endpoint=app_config.common.hf_endpoint,
+                hf_token=app_config.common.hf_token,
+                blocked_datasets=app_config.common.blocked_datasets,
+                hf_jwt_public_keys=hf_jwt_public_keys,
+                hf_jwt_algorithm=app_config.api.hf_jwt_algorithm,
+                external_auth_url=app_config.api.external_auth_url,
+                hf_timeout_seconds=app_config.api.hf_timeout_seconds,
+                max_age_long=app_config.api.max_age_long,
+                max_age_short=app_config.api.max_age_short,
+                storage_clients=storage_clients,
+            ),
+        ),
         Route("/healthcheck", endpoint=healthcheck_endpoint),
         Route("/metrics", endpoint=create_metrics_endpoint()),
         # ^ called by Prometheus

--- a/services/api/src/api/routes/shard.py
+++ b/services/api/src/api/routes/shard.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The HuggingFace Authors.
+
+import logging
+from http import HTTPStatus
+from typing import Optional
+
+from libapi.authentication import auth_check
+from libapi.exceptions import (
+    InvalidParameterError,
+    MissingRequiredParameterError,
+    UnexpectedApiError,
+)
+from libapi.request import get_request_parameter
+from libapi.shard_utils import get_shard_info
+from libapi.utils import (
+    Endpoint,
+    get_cache_entry_from_step,
+    get_json_api_error_response,
+    get_json_error_response,
+    get_json_ok_response,
+)
+from libcommon.exceptions import NotSupportedError
+from libcommon.prometheus import StepProfiler
+from libcommon.storage_client import StorageClient
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+def create_shard_endpoint(
+    hf_endpoint: str,
+    blocked_datasets: list[str],
+    hf_token: Optional[str] = None,
+    hf_jwt_public_keys: Optional[list[str]] = None,
+    hf_jwt_algorithm: Optional[str] = None,
+    external_auth_url: Optional[str] = None,
+    hf_timeout_seconds: Optional[float] = None,
+    max_age_long: int = 0,
+    max_age_short: int = 0,
+    storage_clients: Optional[list[StorageClient]] = None,
+) -> Endpoint:
+    """Create the /shard endpoint handler."""
+
+    async def shard_endpoint(request: Request) -> Response:
+        method = "shard_endpoint"
+        revision: Optional[str] = None
+        with StepProfiler(method=method, step="all"):
+            try:
+                # 1. Validate parameters
+                with StepProfiler(method=method, step="validate parameters"):
+                    dataset = get_request_parameter(request, "dataset")
+                    config = get_request_parameter(request, "config")
+                    split = get_request_parameter(request, "split")
+                    row_str = get_request_parameter(request, "row")
+
+                    if not dataset:
+                        raise MissingRequiredParameterError(
+                            "Parameter 'dataset' is required"
+                        )
+                    if not config:
+                        raise MissingRequiredParameterError(
+                            "Parameter 'config' is required"
+                        )
+                    if not split:
+                        raise MissingRequiredParameterError(
+                            "Parameter 'split' is required"
+                        )
+                    if not row_str:
+                        raise MissingRequiredParameterError(
+                            "Parameter 'row' is required"
+                        )
+
+                    try:
+                        row = int(row_str)
+                    except ValueError:
+                        raise InvalidParameterError(
+                            "Invalid 'row' parameter - must be integer"
+                        )
+
+                    logging.debug(f"/shard {dataset=} {config=} {split=} {row=}")
+
+                # 2. Auth check
+                with StepProfiler(method=method, step="check authentication"):
+                    await auth_check(
+                        dataset=dataset,
+                        external_auth_url=external_auth_url,
+                        request=request,
+                        hf_jwt_public_keys=hf_jwt_public_keys,
+                        hf_jwt_algorithm=hf_jwt_algorithm,
+                        hf_timeout_seconds=hf_timeout_seconds,
+                    )
+
+                # 3. Fetch cached data (single call - optimization)
+                with StepProfiler(method=method, step="get cache entry"):
+                    # Use config-parquet-and-info which has BOTH dataset_info AND parquet_files
+                    result = get_cache_entry_from_step(
+                        processing_step_name="config-parquet-and-info",
+                        dataset=dataset,
+                        config=config,
+                        split=None,  # config-level cache
+                        hf_endpoint=hf_endpoint,
+                        hf_token=hf_token,
+                        blocked_datasets=blocked_datasets,
+                        hf_timeout_seconds=hf_timeout_seconds,
+                        storage_clients=storage_clients,
+                    )
+                    revision = result.get("dataset_git_revision")
+
+                    if result["http_status"] != HTTPStatus.OK:
+                        return get_json_error_response(
+                            content=result["content"],
+                            status_code=result["http_status"],
+                            max_age=max_age_short,
+                            error_code=result["error_code"],
+                            revision=revision,
+                        )
+
+                # 4. Extract split info
+                with StepProfiler(method=method, step="extract split info"):
+                    content = result["content"]
+                    dataset_info = content.get("dataset_info", {})
+                    splits = dataset_info.get("splits", {})
+
+                    if split not in splits:
+                        return get_json_error_response(
+                            content={
+                                "error": f"Split '{split}' not found in config '{config}'"
+                            },
+                            status_code=HTTPStatus.NOT_FOUND,
+                            max_age=max_age_short,
+                            error_code="SplitNotFound",
+                            revision=revision,
+                        )
+
+                    split_info = splits[split]
+                    parquet_files = content.get("parquet_files", [])
+
+                # 5. Compute shard info
+                with StepProfiler(method=method, step="compute shard info"):
+                    try:
+                        shard_result = get_shard_info(
+                            row_index=row,
+                            split_info=split_info,
+                            parquet_files=parquet_files,
+                            split=split,
+                        )
+                    except IndexError as e:
+                        return get_json_error_response(
+                            content={"error": str(e)},
+                            status_code=HTTPStatus.BAD_REQUEST,
+                            max_age=max_age_short,
+                            error_code="RowOutOfBounds",
+                            revision=revision,
+                        )
+                    except ValueError as e:
+                        return get_json_error_response(
+                            content={"error": str(e)},
+                            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                            max_age=max_age_short,
+                            error_code="MetadataCorrupted",
+                            revision=revision,
+                        )
+
+                # 6. Return success
+                with StepProfiler(method=method, step="generate OK response"):
+                    return get_json_ok_response(
+                        content=shard_result,
+                        max_age=max_age_long,
+                        revision=revision,
+                    )
+
+            except Exception as e:
+                error = (
+                    e
+                    if isinstance(
+                        e,
+                        (
+                            InvalidParameterError,
+                            MissingRequiredParameterError,
+                            NotSupportedError,
+                        ),
+                    )
+                    else UnexpectedApiError("Unexpected error.", e)
+                )
+                with StepProfiler(method=method, step="generate API error response"):
+                    return get_json_api_error_response(
+                        error=error, max_age=max_age_short, revision=revision
+                    )
+
+    return shard_endpoint

--- a/services/api/src/api/routes/shard.py
+++ b/services/api/src/api/routes/shard.py
@@ -54,28 +54,18 @@ def create_shard_endpoint(
                     row_str = get_request_parameter(request, "row")
 
                     if not dataset:
-                        raise MissingRequiredParameterError(
-                            "Parameter 'dataset' is required"
-                        )
+                        raise MissingRequiredParameterError("Parameter 'dataset' is required")
                     if not config:
-                        raise MissingRequiredParameterError(
-                            "Parameter 'config' is required"
-                        )
+                        raise MissingRequiredParameterError("Parameter 'config' is required")
                     if not split:
-                        raise MissingRequiredParameterError(
-                            "Parameter 'split' is required"
-                        )
+                        raise MissingRequiredParameterError("Parameter 'split' is required")
                     if not row_str:
-                        raise MissingRequiredParameterError(
-                            "Parameter 'row' is required"
-                        )
+                        raise MissingRequiredParameterError("Parameter 'row' is required")
 
                     try:
                         row = int(row_str)
                     except ValueError:
-                        raise InvalidParameterError(
-                            "Invalid 'row' parameter - must be integer"
-                        )
+                        raise InvalidParameterError("Invalid 'row' parameter - must be integer")
 
                     logging.debug(f"/shard {dataset=} {config=} {split=} {row=}")
 
@@ -123,9 +113,7 @@ def create_shard_endpoint(
 
                     if split not in splits:
                         return get_json_error_response(
-                            content={
-                                "error": f"Split '{split}' not found in config '{config}'"
-                            },
+                            content={"error": f"Split '{split}' not found in config '{config}'"},
                             status_code=HTTPStatus.NOT_FOUND,
                             max_age=max_age_short,
                             error_code="SplitNotFound",
@@ -183,8 +171,6 @@ def create_shard_endpoint(
                     else UnexpectedApiError("Unexpected error.", e)
                 )
                 with StepProfiler(method=method, step="generate API error response"):
-                    return get_json_api_error_response(
-                        error=error, max_age=max_age_short, revision=revision
-                    )
+                    return get_json_api_error_response(error=error, max_age=max_age_short, revision=revision)
 
     return shard_endpoint

--- a/services/api/src/api/routes/shard.py
+++ b/services/api/src/api/routes/shard.py
@@ -9,6 +9,8 @@ from libapi.authentication import auth_check
 from libapi.exceptions import (
     InvalidParameterError,
     MissingRequiredParameterError,
+    ResponseNotFoundError,
+    ResponseNotReadyError,
     UnexpectedApiError,
 )
 from libapi.request import get_request_parameter
@@ -166,6 +168,8 @@ def create_shard_endpoint(
                             InvalidParameterError,
                             MissingRequiredParameterError,
                             NotSupportedError,
+                            ResponseNotFoundError,
+                            ResponseNotReadyError,
                         ),
                     )
                     else UnexpectedApiError("Unexpected error.", e)

--- a/services/api/tests/routes/test_shard.py
+++ b/services/api/tests/routes/test_shard.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The HuggingFace Authors.
+
+import pytest
+from unittest.mock import patch
+from starlette.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.routing import Route
+from api.routes.shard import create_shard_endpoint
+
+
+@pytest.fixture
+def client() -> TestClient:
+    endpoint = create_shard_endpoint(
+        hf_endpoint="https://huggingface.co",
+        blocked_datasets=[],
+        hf_token="token",
+    )
+    app = Starlette(routes=[Route("/shard", endpoint=endpoint)])
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_cache_response():
+    """Standard multi-shard dataset response from config-parquet-and-info."""
+    return {
+        "content": {
+            "dataset_info": {
+                "splits": {
+                    "train": {
+                        "num_examples": 400,
+                        "shard_lengths": [200, 200],
+                        "original_shard_lengths": [100, 100, 100, 100]
+                    }
+                }
+            },
+            "parquet_files": [
+                {"filename": "train-00000-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
+                {"filename": "train-00001-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
+            ],
+            "partial": False
+        },
+        "http_status": 200,
+        "error_code": None,
+        "dataset_git_revision": "abc123",
+        "job_runner_version": 1,
+        "progress": 1.0,
+    }
+
+
+@pytest.fixture
+def mock_legacy_cache_response():
+    """Legacy dataset without original_shard_lengths."""
+    return {
+        "content": {
+            "dataset_info": {
+                "splits": {
+                    "train": {
+                        "num_examples": 400,
+                        "shard_lengths": [200, 200],
+                        # Note: NO original_shard_lengths key
+                    }
+                }
+            },
+            "parquet_files": [
+                {"filename": "train-00000-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
+                {"filename": "train-00001-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
+            ],
+            "partial": False
+        },
+        "http_status": 200,
+        "error_code": None,
+        "dataset_git_revision": "abc123",
+        "job_runner_version": 1,
+        "progress": 1.0,
+    }
+
+
+def test_shard_endpoint_success(client: TestClient, mock_cache_response):
+    """GET /shard?dataset=X&config=Y&split=train&row=150 -> 200"""
+    with patch("api.routes.shard.get_cache_entry_from_step", return_value=mock_cache_response):
+        response = client.get("/shard?dataset=test&config=default&split=train&row=150")
+        assert response.status_code == 200
+        content = response.json()
+        assert content["row_index"] == 150
+        assert content["original_shard_index"] == 1
+        assert content["parquet_shard_index"] == 0
+
+
+def test_shard_endpoint_legacy_dataset(client: TestClient, mock_legacy_cache_response):
+    """Legacy dataset without original_shard_lengths -> graceful null"""
+    with patch("api.routes.shard.get_cache_entry_from_step", return_value=mock_legacy_cache_response):
+        response = client.get("/shard?dataset=test&config=default&split=train&row=150")
+        assert response.status_code == 200
+        content = response.json()
+        assert content["original_shard_index"] is None
+        assert content["original_shard_info"] is not None
+
+
+def test_shard_endpoint_row_out_of_bounds(client: TestClient, mock_cache_response):
+    """row=500 when num_examples=400 -> 400 Bad Request"""
+    with patch("api.routes.shard.get_cache_entry_from_step", return_value=mock_cache_response):
+        response = client.get("/shard?dataset=test&config=default&split=train&row=500")
+        assert response.status_code == 400
+        assert "X-Error-Code" in response.headers
+
+
+def test_shard_endpoint_missing_params(client: TestClient):
+    """Missing required parameters -> 422"""
+    response = client.get("/shard?dataset=test")  # Missing config, split, row
+    assert response.status_code == 422

--- a/services/api/tests/routes/test_shard.py
+++ b/services/api/tests/routes/test_shard.py
@@ -132,7 +132,7 @@ def test_shard_endpoint_row_out_of_bounds(client: TestClient, mock_cache_respons
     with patch("api.routes.shard.get_cache_entry_from_step", return_value=mock_cache_response):
         response = client.get("/shard?dataset=test&config=default&split=train&row=500")
         assert response.status_code == 400
-        assert "X-Error-Code" in response.headers
+        assert response.headers.get("X-Error-Code") == "RowOutOfBounds"
 
 
 def test_shard_endpoint_missing_params(client: TestClient):

--- a/services/api/tests/routes/test_shard.py
+++ b/services/api/tests/routes/test_shard.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 The HuggingFace Authors.
 
-import pytest
 from unittest.mock import patch
-from starlette.testclient import TestClient
+
+import pytest
 from starlette.applications import Starlette
 from starlette.routing import Route
+from starlette.testclient import TestClient
+
 from api.routes.shard import create_shard_endpoint
 
 
@@ -30,15 +32,29 @@ def mock_cache_response():
                     "train": {
                         "num_examples": 400,
                         "shard_lengths": [200, 200],
-                        "original_shard_lengths": [100, 100, 100, 100]
+                        "original_shard_lengths": [100, 100, 100, 100],
                     }
                 }
             },
             "parquet_files": [
-                {"filename": "train-00000-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
-                {"filename": "train-00001-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
+                {
+                    "filename": "train-00000-of-00002.parquet",
+                    "split": "train",
+                    "dataset": "test",
+                    "config": "default",
+                    "url": "...",
+                    "size": 1000,
+                },
+                {
+                    "filename": "train-00001-of-00002.parquet",
+                    "split": "train",
+                    "dataset": "test",
+                    "config": "default",
+                    "url": "...",
+                    "size": 1000,
+                },
             ],
-            "partial": False
+            "partial": False,
         },
         "http_status": 200,
         "error_code": None,
@@ -63,10 +79,24 @@ def mock_legacy_cache_response():
                 }
             },
             "parquet_files": [
-                {"filename": "train-00000-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
-                {"filename": "train-00001-of-00002.parquet", "split": "train", "dataset": "test", "config": "default", "url": "...", "size": 1000},
+                {
+                    "filename": "train-00000-of-00002.parquet",
+                    "split": "train",
+                    "dataset": "test",
+                    "config": "default",
+                    "url": "...",
+                    "size": 1000,
+                },
+                {
+                    "filename": "train-00001-of-00002.parquet",
+                    "split": "train",
+                    "dataset": "test",
+                    "config": "default",
+                    "url": "...",
+                    "size": 1000,
+                },
             ],
-            "partial": False
+            "partial": False,
         },
         "http_status": 200,
         "error_code": None,

--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -361,6 +361,17 @@ splits = {splits}
 df = {function}("hf://datasets/{dataset}/" + splits["{first_split}"])"""
 
 
+POLARS_CODE = """import polars as pl
+{comment}
+df = {function}("hf://datasets/{dataset}/{pattern}"{args})"""
+
+
+POLARS_CODE_SPLITS = """import polars as pl
+{comment}
+splits = {splits}
+df = {function}("hf://datasets/{dataset}/" + splits["{first_split}"]{args})"""
+
+
 WEBDATASET_CODE = """import webdataset as wds
 from huggingface_hub import HfFileSystem, get_token, hf_hub_url
 {comment}
@@ -385,17 +396,8 @@ urls = f"pipe: curl -s -L -H 'Authorization:Bearer {{get_token()}}' {{'::'.join(
 ds = {function}(urls).decode()"""
 
 
-def get_compatible_libraries_for_json(
-    dataset: str, hf_token: Optional[str], login_required: bool
-) -> CompatibleLibrary:
-    library: DatasetLibrary
-    builder_configs = get_builder_configs_with_simplified_data_files(dataset, module_name="json", hf_token=hf_token)
-    for config in builder_configs:
-        if any(len(data_files) != 1 for data_files in config.data_files.values()):
-            raise DatasetWithTooComplexDataFilesPatternsError(
-                f"Failed to simplify json data files pattern: {config.data_files}"
-            )
-    loading_codes: list[LoadingCode] = [
+def _init_empty_loading_codes(builder_configs: list[BuilderConfig]) -> list[LoadingCode]:
+    return [
         {
             "config_name": config.name,
             "arguments": {"splits": {str(split): data_files[0] for split, data_files in config.data_files.items()}},
@@ -403,6 +405,22 @@ def get_compatible_libraries_for_json(
         }
         for config in builder_configs
     ]
+
+
+def get_compatible_libraries_for_json(
+    dataset: str, hf_token: Optional[str], login_required: bool
+) -> list[CompatibleLibrary]:
+    library: DatasetLibrary
+    compatible_libraries: list[CompatibleLibrary] = []
+    builder_configs = get_builder_configs_with_simplified_data_files(dataset, module_name="json", hf_token=hf_token)
+    for config in builder_configs:
+        if any(len(data_files) != 1 for data_files in config.data_files.values()):
+            raise DatasetWithTooComplexDataFilesPatternsError(
+                f"Failed to simplify json data files pattern: {config.data_files}"
+            )
+
+    # Pandas or Dask
+    loading_codes = _init_empty_loading_codes(builder_configs)
     is_single_file = all(
         "*" not in data_file and "[" not in data_file
         for loading_code in loading_codes
@@ -412,8 +430,12 @@ def get_compatible_libraries_for_json(
     if is_single_file:
         library = "pandas"
         function = "pd.read_json"
-        for loading_code in loading_codes:
+        for loading_code in list(loading_codes):
             first_file = f"datasets/{dataset}/" + next(iter(loading_code["arguments"]["splits"].values()))
+            # TODO: resolve file if it has wildcard characters
+            if first_file.endswith("*"):
+                loading_codes.remove(loading_code)
+                continue
             if ".jsonl" in first_file or HfFileSystem(token=hf_token).open(first_file, "r").read(1) != "[":
                 args = ", lines=True"
                 loading_code["arguments"]["lines"] = True
@@ -450,25 +472,63 @@ def get_compatible_libraries_for_json(
                     first_split=next(iter(loading_code["arguments"]["splits"])),
                     comment=comment,
                 )
-    return {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    if loading_codes:
+        compatible_libraries.append(
+            {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+        )
+
+    # Polars
+    loading_codes = _init_empty_loading_codes(builder_configs)
+    library = "polars"
+    function = "pl.read_json"
+    for loading_code in list(loading_codes):
+        first_file = f"datasets/{dataset}/" + next(iter(loading_code["arguments"]["splits"].values()))
+        # TODO: resolve file if it has wildcard characters
+        if first_file.endswith("*"):
+            loading_codes.remove(loading_code)
+            continue
+        if ".jsonl" in first_file or HfFileSystem(token=hf_token).open(first_file, "r").read(1) != "[":
+            function = "pl.read_ndjson"
+        if len(loading_code["arguments"]["splits"]) == 1:
+            pattern = next(iter(loading_code["arguments"]["splits"].values()))
+            loading_code["code"] = DASK_CODE.format(
+                function=function,
+                dataset=dataset,
+                pattern=pattern,
+                args="",
+                comment=comment,
+            )
+        else:
+            loading_code["code"] = DASK_CODE_SPLITS.format(
+                function=function,
+                dataset=dataset,
+                splits=loading_code["arguments"]["splits"],
+                first_split=next(iter(loading_code["arguments"]["splits"])),
+                args="",
+                comment=comment,
+            )
+    if loading_codes:
+        compatible_libraries.append(
+            {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+        )
+
+    return compatible_libraries
 
 
-def get_compatible_libraries_for_csv(dataset: str, hf_token: Optional[str], login_required: bool) -> CompatibleLibrary:
+def get_compatible_libraries_for_csv(
+    dataset: str, hf_token: Optional[str], login_required: bool
+) -> list[CompatibleLibrary]:
     library: DatasetLibrary
+    compatible_libraries: list[CompatibleLibrary] = []
     builder_configs = get_builder_configs_with_simplified_data_files(dataset, module_name="csv", hf_token=hf_token)
     for config in builder_configs:
         if any(len(data_files) != 1 for data_files in config.data_files.values()):
             raise DatasetWithTooComplexDataFilesPatternsError(
                 f"Failed to simplify csv data files pattern: {config.data_files}"
             )
-    loading_codes: list[LoadingCode] = [
-        {
-            "config_name": config.name,
-            "arguments": {"splits": {str(split): data_files[0] for split, data_files in config.data_files.items()}},
-            "code": "",
-        }
-        for config in builder_configs
-    ]
+
+    # Pandas or Dask
+    loading_codes = _init_empty_loading_codes(builder_configs)
     is_single_file = all(
         "*" not in data_file and "[" not in data_file
         for loading_code in loading_codes
@@ -515,27 +575,59 @@ def get_compatible_libraries_for_csv(dataset: str, hf_token: Optional[str], logi
                     first_split=next(iter(loading_code["arguments"]["splits"])),
                     comment=comment,
                 )
-    return {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    compatible_libraries.append(
+        {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    )
+
+    # Polars
+    loading_codes = _init_empty_loading_codes(builder_configs)
+    library = "polars"
+    function = "pl.read_csv"
+    for loading_code in loading_codes:
+        first_file = next(iter(loading_code["arguments"]["splits"].values()))
+        if ".tsv" in first_file:
+            args = ', separator="\\t"'
+        else:
+            args = ""
+        if len(loading_code["arguments"]["splits"]) == 1:
+            pattern = next(iter(loading_code["arguments"]["splits"].values()))
+            loading_code["code"] = POLARS_CODE.format(
+                function=function,
+                dataset=dataset,
+                pattern=pattern,
+                args=args,
+                comment=comment,
+            )
+        else:
+            loading_code["code"] = POLARS_CODE_SPLITS.format(
+                function=function,
+                dataset=dataset,
+                splits=loading_code["arguments"]["splits"],
+                first_split=next(iter(loading_code["arguments"]["splits"])),
+                args=args,
+                comment=comment,
+            )
+    compatible_libraries.append(
+        {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    )
+
+    return compatible_libraries
 
 
 def get_compatible_libraries_for_parquet(
     dataset: str, hf_token: Optional[str], login_required: bool
-) -> CompatibleLibrary:
+) -> list[CompatibleLibrary]:
     library: DatasetLibrary
+    compatible_libraries: list[CompatibleLibrary] = []
     builder_configs = get_builder_configs_with_simplified_data_files(dataset, module_name="parquet", hf_token=hf_token)
     for config in builder_configs:
         if any(len(data_files) != 1 for data_files in config.data_files.values()):
             raise DatasetWithTooComplexDataFilesPatternsError(
                 f"Failed to simplify parquet data files pattern: {config.data_files}"
             )
-    loading_codes: list[LoadingCode] = [
-        {
-            "config_name": config.name,
-            "arguments": {"splits": {str(split): data_files[0] for split, data_files in config.data_files.items()}},
-            "code": "",
-        }
-        for config in builder_configs
-    ]
+
+    # Pandas or Dask
+    loading_codes = _init_empty_loading_codes(builder_configs)
     is_single_file = all(
         "*" not in data_file and "[" not in data_file
         for loading_code in loading_codes
@@ -577,13 +669,45 @@ def get_compatible_libraries_for_parquet(
                     first_split=next(iter(loading_code["arguments"]["splits"])),
                     comment=comment,
                 )
-    return {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    compatible_libraries.append(
+        {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    )
+
+    # Polars
+    loading_codes = _init_empty_loading_codes(builder_configs)
+    library = "polars"
+    function = "pl.read_parquet"
+    for loading_code in loading_codes:
+        if len(loading_code["arguments"]["splits"]) == 1:
+            pattern = next(iter(loading_code["arguments"]["splits"].values()))
+            loading_code["code"] = POLARS_CODE.format(
+                function=function,
+                dataset=dataset,
+                pattern=pattern,
+                args="",
+                comment=comment,
+            )
+        else:
+            loading_code["code"] = POLARS_CODE_SPLITS.format(
+                function=function,
+                dataset=dataset,
+                splits=loading_code["arguments"]["splits"],
+                first_split=next(iter(loading_code["arguments"]["splits"])),
+                args="",
+                comment=comment,
+            )
+    compatible_libraries.append(
+        {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    )
+
+    return compatible_libraries
 
 
 def get_compatible_libraries_for_webdataset(
     dataset: str, hf_token: Optional[str], login_required: bool
-) -> CompatibleLibrary:
+) -> list[CompatibleLibrary]:
     library: DatasetLibrary
+    compatible_libraries: list[CompatibleLibrary] = []
     builder_configs = get_builder_configs_with_simplified_data_files(
         dataset, module_name="webdataset", hf_token=hf_token
     )
@@ -592,14 +716,7 @@ def get_compatible_libraries_for_webdataset(
             raise DatasetWithTooComplexDataFilesPatternsError(
                 f"Failed to simplify webdataset data files pattern: {config.data_files}"
             )
-    loading_codes: list[LoadingCode] = [
-        {
-            "config_name": config.name,
-            "arguments": {"splits": {str(split): data_files[0] for split, data_files in config.data_files.items()}},
-            "code": "",
-        }
-        for config in builder_configs
-    ]
+    loading_codes: list[LoadingCode] = _init_empty_loading_codes(builder_configs)
     library = "webdataset"
     function = "wds.WebDataset"
     comment = LOGIN_COMMENT if login_required else ""
@@ -617,111 +734,14 @@ def get_compatible_libraries_for_webdataset(
                 first_split=next(iter(loading_code["arguments"]["splits"])),
                 comment=comment,
             )
-    return {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    compatible_libraries.append(
+        {"language": "python", "library": library, "function": function, "loading_codes": loading_codes}
+    )
+
+    return compatible_libraries
 
 
-def get_polars_compatible_library(
-    builder_name: str, dataset: str, hf_token: Optional[str], login_required: bool
-) -> Optional[CompatibleLibrary]:
-    if builder_name in ["parquet", "csv", "json"]:
-        builder_configs = get_builder_configs_with_simplified_data_files(
-            dataset, module_name=builder_name, hf_token=hf_token
-        )
-
-        for config in builder_configs:
-            if any(len(data_files) != 1 for data_files in config.data_files.values()):
-                raise DatasetWithTooComplexDataFilesPatternsError(
-                    f"Failed to simplify parquet data files pattern: {config.data_files}"
-                )
-
-        loading_codes: list[LoadingCode] = [
-            {
-                "config_name": config.name,
-                "arguments": {
-                    "splits": {str(split): data_files[0] for split, data_files in config.data_files.items()}
-                },
-                "code": "",
-            }
-            for config in builder_configs
-        ]
-
-    compatible_library: CompatibleLibrary = {
-        "language": "python",
-        "library": "polars",
-        "function": "",
-        "loading_codes": [],
-    }
-
-    def fmt_code(
-        *,
-        read_func: str,
-        splits: dict[str, str],
-        args: str,
-        dataset: str = dataset,
-        login_required: bool = login_required,
-    ) -> str:
-        if not (args.startswith(", ") or args == ""):
-            msg = f"incorrect args format: {args = !s}"
-            raise ValueError(msg)
-
-        login_comment = LOGIN_COMMENT if login_required else ""
-
-        if len(splits) == 1:
-            path = next(iter(splits.values()))
-            return f"""\
-import polars as pl
-{login_comment}
-df = pl.{read_func}('hf://datasets/{dataset}/{path}'{args})
-"""
-        else:
-            first_split = next(iter(splits))
-            return f"""\
-import polars as pl
-{login_comment}
-splits = {splits}
-df = pl.{read_func}('hf://datasets/{dataset}/' + splits['{first_split}']{args})
-"""
-
-    args = ""
-
-    if builder_name == "parquet":
-        read_func = "read_parquet"
-        compatible_library["function"] = f"pl.{read_func}"
-    elif builder_name == "csv":
-        read_func = "read_csv"
-        compatible_library["function"] = f"pl.{read_func}"
-
-        first_file = next(iter(loading_codes[0]["arguments"]["splits"].values()))
-
-        if ".tsv" in first_file:
-            args = f"{args}, separator='\\t'"
-
-    elif builder_name == "json":
-        first_file = f"datasets/{dataset}/" + next(iter(loading_codes[0]["arguments"]["splits"].values()))
-        if "*" in first_file:
-            # The pattern 'datasets/[dataset]/**/*' is not supported yet
-            return None
-        is_json_lines = ".jsonl" in first_file or HfFileSystem(token=hf_token).open(first_file, "r").read(1) != "["
-
-        if is_json_lines:
-            read_func = "read_ndjson"
-        else:
-            read_func = "read_json"
-
-        compatible_library["function"] = f"pl.{read_func}"
-    else:
-        return None
-
-    for loading_code in loading_codes:
-        splits = loading_code["arguments"]["splits"]
-        loading_code["code"] = fmt_code(read_func=read_func, splits=splits, args=args)
-
-    compatible_library["loading_codes"] = loading_codes
-
-    return compatible_library
-
-
-get_compatible_library_for_builder: dict[str, Callable[[str, Optional[str], bool], CompatibleLibrary]] = {
+get_compatible_library_for_builder: dict[str, Callable[[str, Optional[str], bool], list[CompatibleLibrary]]] = {
     "webdataset": get_compatible_libraries_for_webdataset,
     "json": get_compatible_libraries_for_json,
     "csv": get_compatible_libraries_for_csv,
@@ -793,27 +813,13 @@ def compute_compatible_libraries_response(
             formats.append(get_format_for_builder[builder_name])
         if builder_name in get_compatible_library_for_builder:
             try:
-                compatible_library = get_compatible_library_for_builder[builder_name](
-                    dataset, hf_token, login_required
-                )
-                libraries.append(compatible_library)
+                libraries += get_compatible_library_for_builder[builder_name](dataset, hf_token, login_required)
             except NotImplementedError:
                 pass
         # mlcroissant library
         libraries.append(
             get_mlcroissant_compatible_library(dataset, infos, login_required=login_required, partial=partial)
         )
-        # polars
-        if (
-            isinstance(builder_name, str)
-            and (
-                v := get_polars_compatible_library(
-                    builder_name, dataset, hf_token=hf_token, login_required=login_required
-                )
-            )
-            is not None
-        ):
-            libraries.append(v)
 
     return DatasetCompatibleLibrariesResponse(libraries=libraries, formats=formats)
 


### PR DESCRIPTION
## Summary
- Adds `/shard` API endpoint that maps a row index to its original input shard and parquet output shard
- Enables data provenance tracking using `original_shard_lengths` field from huggingface/datasets PR #7897
- Single cache call optimization using `config-parquet-and-info`

## API
```
GET /shard?dataset=X&config=Y&split=Z&row=N
```

## Files Changed
- `libs/libapi/src/libapi/shard_utils.py` - Core algorithm
- `services/api/src/api/routes/shard.py` - Endpoint handler  
- `services/api/src/api/app.py` - Route registration
- `docs/source/openapi.json` - API specification
- Unit, integration, and E2E tests

## Test Plan
- [ ] Unit tests pass (`libs/libapi/tests/test_shard_utils.py`)
- [ ] Integration tests pass (`services/api/tests/routes/test_shard.py`)
- [ ] E2E tests pass (`e2e/tests/test_56_shard.py`)
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /shard API to return shard mapping for a dataset/config/split/row, including parquet shard info and optional original-shard metadata.
  * Exposed configurable indexing parallelism for dataset indexing (adjustable max_parallelism).

* **Documentation**
  * OpenAPI updated with ShardInfoResponse schema and new /shard path and responses.

* **Bug Fixes**
  * Improved validation and explicit error responses for missing/invalid params, out-of-bounds rows, and corrupted metadata.

* **Tests**
  * Added unit and end-to-end tests covering success, legacy-data fallback, validation, and out-of-bounds scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->